### PR TITLE
Enable multiplatform builds on Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -23,10 +23,13 @@ blocks:
       jobs:
         - name: "Build Docker Image"
           commands:
+            - checkout 
+            - sudo bash enable-docker-containerd
+            - docker run --privileged --rm tonistiigi/binfmt --install all
             - git clone https://github.com/operately/operately.git
             - cd operately
             - artifact pull workflow version
-            - docker build -f Dockerfile.prod -t operately/operately:$(cat version) .
+            - docker build -f Dockerfile.prod --platform linux/amd64,linux/arm64 -t operately/operately:$(cat version) .
             - docker push operately/operately:$(cat version)
 
   - name: "GitHub Release"

--- a/enable-docker-containerd
+++ b/enable-docker-containerd
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Enable containerd image store for multi-platform builds. Run with sudo
+# See: https://docs.docker.com/engine/storage/containerd/
+
+# try to install the config file
+config_file=/etc/docker/daemon.json
+
+if [ -f "$config_file" ]; then
+    echo "ERROR: $config_file already exists, aborting..."
+    exit 1
+fi
+
+echo '
+{
+  "features": {
+    "containerd-snapshotter": true
+  }
+}
+' > $config_file
+
+# restart docker daemon
+systemctl restart docker
+
+# check driver is expected
+expected_driver="io.containerd.snapshotter"
+current_driver=$(docker info -f '{{ .DriverStatus }}')
+
+echo "$current_driver" | grep -q "$expected_driver"
+if [ $? -ne 0 ]; then
+    echo "ERROR: expected Docker driver $expected_driver but got $current_driver instead"
+    exit 1
+fi


### PR DESCRIPTION
@shiroyasha this PR configures Semaphore to run multiplatform builds using QEMU. The docker build, however, fails. You can see the build error here: https://rtx.semaphoreci.com/jobs/c4702f16-966b-4e2e-a160-e832ddaffb92

I've tried the same build command on Docker Desktop running on my macbook and I have the same exact error. Since I'm not familiar with Elixir compilation, I'm not sure how to debug the problem. Not sure if this is caused by emulation, the build order in the Dockerfile or something else. So I leave this partial solution here.

I suggest trying to build the multiplatform image using Docker Desktop first as it's easier to debug and the solution will probably also work on the Linux agent on Semaphore.